### PR TITLE
Read connection information from RABBITMQ_URL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[*Makefile]
+indent_size = 4
+indent_style = tab

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ cronq-runner
 
 The ``runner`` executes tasks, and should be run on hosts that will actually perform work. There is no limit to the number of runners that can execute.
 
-The runner requires ``/var/log/cronq/`` to exist and be writable by the user executing the runner.
+The runner requires ``/var/log/cronq/`` to exist and be writable by the user executing the runner. If it is not, logs will be written to ``/tmp``.
 
 .. code-block:: bash
 

--- a/contrib/publish.py
+++ b/contrib/publish.py
@@ -1,15 +1,16 @@
-import time
 import json
+import os
+import time
 
 from haigha.connection import Connection
 from haigha.message import Message
 from uuid import uuid4
 
 connection = Connection(
-    user='guest',
-    password='guest',
+    user=os.getenv('RABBITMQ_USER'),
+    password=os.getenv('RABBITMQ_PASS'),
     vhost='/',
-    host='rabbit-host',
+    host=os.getenv('RABBITMQ_HOSTS', 'localhost').split(',')[0],
     heartbeat=None,
     debug=True)
 
@@ -23,10 +24,16 @@ ch.queue.bind('cronq_results', 'cronq', 'cronq_results')
 while True:
     print 'publish'
     cmd = {
-        'job_id': str(uuid4()),
-        'cmd': 'sleep 1'
+        "cmd": "sleep 1",
+        "job_id": 1024,
+        "name": "[TEST] A test job",
+        "run_id": "1234"
     }
-    ch.basic.publish(Message(json.dumps(cmd), application_headers={
-        'src': 'test'
-    }), 'cronq', 'cronq')
+    ch.basic.publish(
+        Message(json.dumps(cmd), application_headers={
+            'src': 'test'
+        }),
+        exchange='cronq',
+        routing_key='test'
+    )
     time.sleep(1)

--- a/contrib/publish.py
+++ b/contrib/publish.py
@@ -1,9 +1,9 @@
-import json
 import time
-from uuid import uuid4
+import json
 
 from haigha.connection import Connection
 from haigha.message import Message
+from uuid import uuid4
 
 connection = Connection(
     user='guest',

--- a/cronq/backends/mysql.py
+++ b/cronq/backends/mysql.py
@@ -334,7 +334,7 @@ class Storage(object):
         success = self.publisher.publish(job.routing_key, job_doc, uuid4().hex)
         if not success:
             logger.warning('[cronq_job_id:{0}] Error publishing {1} - {2}'.format(
-                job.id, job.name, e))
+                job.id, job.name))
 
         session.close()
         return True

--- a/cronq/backends/mysql.py
+++ b/cronq/backends/mysql.py
@@ -333,7 +333,7 @@ class Storage(object):
         logger.info("try publish")
         success = self.publisher.publish(job.routing_key, job_doc, uuid4().hex)
         if not success:
-            logger.warning('[cronq_job_id:{0}] Error publishing {1} - {2}'.format(
+            logger.warning('[cronq_job_id:{0}] Error publishing {1}'.format(
                 job.id, job.name))
 
         session.close()

--- a/cronq/backends/mysql.py
+++ b/cronq/backends/mysql.py
@@ -314,7 +314,6 @@ class Storage(object):
             session.close()
             return
 
-
         # update job time
         job = self.update_job_time(session, job)
         if not job:

--- a/cronq/config.py
+++ b/cronq/config.py
@@ -9,10 +9,14 @@ if os.getenv('RABBITMQ_HOSTS', None) is not None:
 else:
     hosts = [os.getenv('RABBITMQ_HOST', 'localhost')]
 
+default_log_path = '/var/log/cronq'
+if not os.path.exists('/var/log/cronq'):
+    default_log_path = '/tmp'
+
 DATABASE_URL = os.getenv(
     'CRONQ_MYSQL',
     'mysql+mysqlconnector://root@localhost/cronq')
-LOG_PATH = os.getenv('LOG_PATH', '/var/log/cronq')
+LOG_PATH = os.getenv('LOG_PATH', default_log_path)
 QUEUE = os.getenv('CRONQ_QUEUE', 'cronq_jobs')
 RABBITMQ_HOSTS = hosts
 RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')

--- a/cronq/config.py
+++ b/cronq/config.py
@@ -17,3 +17,11 @@ QUEUE = os.getenv('CRONQ_QUEUE', 'cronq_jobs')
 RABBITMQ_HOSTS = hosts
 RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
 RABBITMQ_PASS = os.getenv('RABBITMQ_PASS', 'guest')
+
+default_rabbitmq_url = 'amqp://{0}:{1}@{2}/'.format(
+    RABBITMQ_USER,
+    RABBITMQ_PASS,
+    ','.join(RABBITMQ_HOSTS)
+)
+
+RABBITMQ_URL = os.getenv('RABBITMQ_URL', default_rabbitmq_url)

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -291,7 +291,7 @@ class Publisher(object):
 def connect():
     hosts, user, password, vhost, port, heartbeat = parse_url(RABBITMQ_URL)
 
-    logger.info('Hosts are: {0}'.format(RABBITMQ_HOSTS))
+    logger.info('Hosts are: {0}'.format(hosts))
     rabbit_logger = logging.getLogger('amqp-dispatcher.haigha')
     conn = connect_to_hosts(
         RabbitConnection,

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -265,7 +265,7 @@ class QueueConnection(object):
                              headers,
                              body,
                              seconds):
-        data = ujson.dumps(body)
+        data = json.dumps(body)
         return self.publish_delayed(exchange,
                                     routing_key,
                                     headers,

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -302,7 +302,6 @@ def connect():
         vhost=vhost,
         heartbeat=heartbeat,
         logger=rabbit_logger,
-        heartbeat=heartbeat,
         transport='gevent'
     )
     return conn

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -28,44 +28,54 @@ class QueueConnection(object):
 
     Simple instantiation:
 
-        queueconnection = QueueConnection(os.getenv('RABBITMQ_URL', 'amqp://guest:guest@localhost'))
+        RABBITMQ_URL = os.getenv('RABBITMQ_URL', 'amqp://guest@localhost')
+        queueconnection = QueueConnection(RABBITMQ_URL)
 
-    Publishing requires konwing the exchange, routing_key, (headers) and the string body
+    Publishing requires knowing the exchange, routing_key, (headers) and
+    the string body:
 
+        # We don't really use headers
+        # look up AMQP stuff if you are interested
         queueconnection.publish(
             exchange='exchange',
             routing_key='routing_key',
-            headers={}, # We don't really use these, look up AMQP stuff if you are interested
+            headers={},
             body='String Body'
         )
 
-    Usually we want to publish JSON so there is a method that will serialize a dict for you
+    Usually we want to publish JSON so there is a method that will serialize
+    a dict for you:
 
+        # We don't really use headers
+        # look up AMQP stuff if you are interested
         queueconnection.publish_json(
             exchange='exchange',
             routing_key='routing_key',
-            headers={}, # We don't really use these, look up AMQP stuff if you are interested
+            headers={},
             body={'key': 'value'}
         )
 
-    All of these are asynchronous publishes to the server, if you want to make sure that
-    these at least make it to the server you can turn on publisher confirmations. Sync
-    calls take longer so they aren't on by default. Turning them on is done by passing
-    `confirm=True` to the constructor.
+    All of these are asynchronous publishes to the server, if you want to make
+    sure that these at least make it to the server you can turn on publisher
+    confirmations. Sync calls take longer so they aren't on by default. Turning
+    them on is done by passing `confirm=True` to the constructor.
 
-        queueconnection = QueueConnection(os.getenv('RABBITMQHOST', 'localhost'), confirm=True)
+        RABBITMQ_URL = os.getenv('RABBITMQ_URL', 'amqp://guest@localhost')
+        queueconnection = QueueConnection(RABBITMQ_URL, confirm=True)
 
     Now publishes will return a bool of whether the publish succeeded.
 
+        # We don't really use headers
+        # look up AMQP stuff if you are interested
         succeeded = queueconnection.publish(
             exchange='exchange',
             routing_key='routing_key',
-            headers={}, # We don't really use these, look up AMQP stuff if you are interested
+            headers={},
             body='String Body'
         )
 
-    Without `confirm=True` the return value of publish will only indicate if the message
-    was written to a connection successfully.
+    Without `confirm=True` the return value of publish will only indicate if
+    the message was written to a connection successfully.
 
     """
     def __init__(self, url=None, confirm=False):

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -285,7 +285,7 @@ class QueueConnection(object):
 class Publisher(object):
 
     def __init__(self):
-        self._connection = QueueConnection(confirm=True)
+        self._connection = QueueConnection(RABBITMQ_URL, confirm=True)
 
     def publish(self, routing_key, job, run_id):
         cmd = {

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -113,8 +113,7 @@ class QueueConnection(object):
                 password=self._connection_password,
                 vhost=self._connection_path,
                 close_cb=self._close_cb,
-                heartbeat=self._connection_heartbeat,
-                transport='gevent'
+                heartbeat=self._connection_heartbeat
             )
         except socket.error as exc:
             self._logger.error('Error connecting to rabbitmq {}'.format(exc))
@@ -301,8 +300,7 @@ def connect():
         password=password,
         vhost=vhost,
         heartbeat=heartbeat,
-        logger=rabbit_logger,
-        transport='gevent'
+        logger=rabbit_logger
     )
     return conn
 

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -76,7 +76,7 @@ class QueueConnection(object):
 
     """
     def __init__(self, url=None, confirm=False):
-        if url is  None:
+        if url is None:
             url = RABBITMQ_URL
         hosts, user, password, vhost, port, heartbeat = parse_url(RABBITMQ_URL)
         self._connection_hosts = hosts

--- a/cronq/queue_connection.py
+++ b/cronq/queue_connection.py
@@ -120,6 +120,7 @@ class QueueConnection(object):
         try:
             self._connection = RabbitConnection(
                 host=host,
+                port=self._connection_port,
                 user=self._connection_user,
                 password=self._connection_password,
                 vhost=self._connection_path,
@@ -340,6 +341,10 @@ def parse_url(rabbitmq_url):
     password = cp.password
     vhost = cp.path
     query = cp.query
+
+    port = 5672
+    if cp.port:
+        port = cp.port
 
     # workaround for bug in 12.04
     if '?' in vhost and query == '':

--- a/cronq/result_aggregator.py
+++ b/cronq/result_aggregator.py
@@ -5,7 +5,6 @@ from uuid import UUID
 
 from cronq.backends.mysql import Storage
 from cronq.queue_connection import connect
-
 from dateutil.parser import parse
 
 logger = logging.getLogger(__name__)
@@ -53,7 +52,7 @@ def create_aggregator(channel):
         data = json.loads(str(msg.body))
         run_id = UUID(hex=data['run_id'])
 
-        logger.info('[cronq_job_id:{0}] [cronq_run_id:{1}] Running job {2}'.format(
+        logger.info('[cronq_job_id:{0}] [cronq_run_id:{1}] Write job result to database: {2}'.format(
             data.get('job_id'), run_id, str(msg.body)
         ))
 
@@ -70,6 +69,7 @@ def create_aggregator(channel):
             data.get('job_id'), run_id
         ))
         storage.update_job_status(
+            run_id,
             data.get('job_id'),
             parse(data.get('x-send-datetime')),
             data.get('type'),

--- a/cronq/runner.py
+++ b/cronq/runner.py
@@ -153,8 +153,8 @@ def create_runner(channel):  # noqa
 
         splits = FILENAME_REGEX.split(data.get('name', 'UNKNOWN'))
         if len(splits) > 1:
-            logfile = "_".join(splits)
-        filename = '{0}/{1}.log'.format(LOG_PATH, logfile.strip('_'))
+            logfile = '-'.join(splits)
+        filename = '{0}/{1}.log'.format(LOG_PATH, logfile.strip('-'))
 
         handler = logging.handlers.WatchedFileHandler(filename)
         log_to_stdout = bool(os.getenv('CRONQ_RUNNER_LOG_TO_STDOUT', False))

--- a/cronq/runner.py
+++ b/cronq/runner.py
@@ -154,7 +154,7 @@ def create_runner(channel):  # noqa
         splits = FILENAME_REGEX.split(data.get('name', 'UNKNOWN'))
         if len(splits) > 1:
             logfile = "_".join(splits)
-        filename = '{0}/{1}.log'.format(LOG_PATH, logfile)
+        filename = '{0}/{1}.log'.format(LOG_PATH, logfile.strip('_'))
 
         handler = logging.handlers.WatchedFileHandler(filename)
         log_to_stdout = bool(os.getenv('CRONQ_RUNNER_LOG_TO_STDOUT', False))


### PR DESCRIPTION
For backwards compatibility, we also read the existing env vars to set a default for `RABBITMQ_URL`.

I'm currently stress-testing the code to ensure it works as desired, so do not merge for now.