### PR TITLE
feat: Use client_properties to set the connection_name for use in the management ui

### DIFF
--- a/cronq/backends/mysql.py
+++ b/cronq/backends/mysql.py
@@ -329,11 +329,15 @@ class Storage(object):
         }
 
         # publish
-        logger.info("try publish")
+        logger.info("[cronq_job_id:{0}] Trying to publish job".format(job.id))
         success = self.publisher.publish(job.routing_key, job_doc, uuid4().hex)
         if not success:
-            logger.warning('[cronq_job_id:{0}] Error publishing {1}'.format(
+            logger.warning('[cronq_job_id:{0}] Error publishing: {1}'.format(
                 job.id, job.name))
+            session.close()
+            return
+
+        logger.info("[cronq_job_id:{0}] Job published".format(job.id))
 
         session.close()
         return True


### PR DESCRIPTION
The consumer_name is based upon the following bits:
- the hostname of the server cronq is running on
- the process id
- a random string made of only ascii characters

This can be used to more easily figure out where consumers are in your infrastructure.

/cc @evanccnyc - Should make it easier to track connections to rabbitmq clusters 😄 .
