### PR TITLE
[WEB] Add job name to title for browser autocomplete

### DIFF
--- a/cronq/templates/base.html
+++ b/cronq/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Cronq Web Panel</title>
+    <title>Cronq Web Panel{% if title %} - {{title}}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">

--- a/cronq/web.py
+++ b/cronq/web.py
@@ -73,7 +73,8 @@ def job(id):
 
     job_doc = g.storage.get_job(id)
     chunks = g.storage.last_event_chunks_for_job(id, 20)
-    return render_template('job.html', job=job_doc, chunks=chunks)
+    title = job_doc.name
+    return render_template('job.html', job=job_doc, chunks=chunks, title=title)
 
 
 @app.route('/run/<string:id>')


### PR DESCRIPTION
This change adds the job name to the `<title>` tag on the Job Details page. 

@josegonzalez I have no tested this change as I don't have CronQ running locally.
