### PR TITLE
Replace pure busy wait with spin lock

### DIFF
--- a/cronq/runner.py
+++ b/cronq/runner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import logging.handlers
 import os
+import random
 import re
 import socket
 import subprocess
@@ -169,6 +170,7 @@ def create_runner(channel):  # noqa
                 break
 
             if nextline == '':
+                time.sleep(0.1 * random.random())
                 continue
 
             try:


### PR DESCRIPTION
Instead of polling continuously for output from the spawned process, which is consuming 100% of CPU on workers, consume all available output and then sleep a random time if there is no additional output available.  The random time is used to prevent collisions if multiple job runners are trying to share a CPU core.

cc: @steverit 