### PR TITLE
feat: add a Dockerfile for building and running cronq within docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+tests
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .dockerignore
+.env
 tests
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2-onbuild
+
+RUN pip install greenlet gevent gunicorn honcho
+
+RUN pip install ./
+
+CMD [ "honcho", "start" ]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+web: gunicorn --access-logfile - -w 1 --bind 0.0.0.0:$PORT --worker-class=gevent cronq.web:app
+results: cronq-results
+injector: cronq-injector
+runner: cronq-runner


### PR DESCRIPTION
@jippi did I do this right? Basically the way this is setup, the command to run can be set to:

- `honcho start web`
- `honcho start cronq-injector`

etc. in order to run specific configurations.
